### PR TITLE
fixes

### DIFF
--- a/Shared/WebView.swift
+++ b/Shared/WebView.swift
@@ -10,14 +10,13 @@ import WebKit
  
 struct WebView: UIViewRepresentable {
  
-    var url: URL
+    var htmlString: String
  
     func makeUIView(context: Context) -> WKWebView {
-        return WKWebView()
+      WKWebView()
     }
  
     func updateUIView(_ webView: WKWebView, context: Context) {
-        let request = URLRequest(url: url)
-        webView.load(request)
+      webView.loadHTMLString(htmlString, baseURL: nil)
     }
 }

--- a/Shared/YouTubeResultParser.swift
+++ b/Shared/YouTubeResultParser.swift
@@ -22,17 +22,16 @@ class YouTubeResultsParserImpl: YouTubeResultParser {
       return .failure(.couldNotCastDataToString)
     }
     let range = NSRange(location: 0, length: string.utf16.count)
-    let regex = try? NSRegularExpression(pattern: "\"videoId\": \"(.*)\"")
+    let regex = try? NSRegularExpression(pattern: "\"videoId\":\"*\"")
     guard let matches = regex?.matches(in: string, options: [], range: range) else {
       return .failure(.matchingFailed)
     }
-    let ids: [String] = matches.compactMap {
-      let fullString = String(string[Range($0.range, in: string)!])
-      // should replace with regex given time:
-      return fullString
-        .replacingOccurrences(of: "\"videoId\": \"", with: "")
-        .replacingOccurrences(of: "\"", with: "")
+    let ids: [String] = matches.compactMap { match in
+      guard let range = Range(match.range(at: 0), in: string) else { return nil }
+      // TODO: should be a regular expression
+      return String(string[range.upperBound..<string.index(range.upperBound, offsetBy: 11)])
     }
+
     let uniqueIds = Set(ids)
     return .success(uniqueIds.compactMap { YouTubeItem(id: $0) })
   }

--- a/Shared/YouTubeService.swift
+++ b/Shared/YouTubeService.swift
@@ -1,0 +1,52 @@
+//
+//  YouTubeService.swift
+//  YouTubeTest
+//
+//  Created by Renen Avneri on 21/06/2022.
+//
+
+import Foundation
+import Combine
+
+protocol YouTubeService {
+  func query(_ string: String) -> AnyPublisher<Data, YouTubeViewModelError>
+}
+
+class YouTubeServiceImpl: YouTubeService {
+  
+  private var session: URLSession
+  private static let queryUrlComponents = URLComponents(string: "https://www.youtube.com/results")!
+
+  init(urlSession: URLSession = .shared) {
+    session = urlSession
+  }
+  
+  func query(_ string: String) -> AnyPublisher<Data, YouTubeViewModelError> {
+    let subject = PassthroughSubject<Data, YouTubeViewModelError>()
+    var components = Self.queryUrlComponents
+    components.queryItems = [URLQueryItem(name: "search_query", value: string)]
+    
+    guard let url = components.url else {
+      return Fail(error: YouTubeViewModelError.couldNotFormURL).eraseToAnyPublisher()
+    }
+    var request = URLRequest(url: url)
+    // reason: https://stackoverflow.com/questions/67032728/urlsession-returns-script-element-still-string-encoded-and-escaped
+    request.setValue("Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:60.0) Gecko/20100101 Firefox/60.0", forHTTPHeaderField:"user-agent")
+    
+    // Note: we may want to specify a queue via URL session configuration
+    let task = session.dataTask(with: request) { data, response, error in
+      if let error = error {
+        subject.send(completion: .failure(.queryReturnedError(error)))
+        return
+      }
+      guard let data = data else {
+        subject.send(completion: .failure(.queryReturnedEmpty))
+        return
+      }
+      subject.send(data)
+      subject.send(completion: .finished)
+    }
+    task.resume()
+    return subject.eraseToAnyPublisher()
+  }
+}

--- a/YouTubeTest.xcodeproj/project.pbxproj
+++ b/YouTubeTest.xcodeproj/project.pbxproj
@@ -23,6 +23,8 @@
 		770659242861D44C007248ED /* YouTubeResultParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = 770659222861D44C007248ED /* YouTubeResultParser.swift */; };
 		770659262861DEF6007248ED /* WebView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 770659252861DEF6007248ED /* WebView.swift */; };
 		770659272861DEF6007248ED /* WebView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 770659252861DEF6007248ED /* WebView.swift */; };
+		77FA47CB28624D8B00E782D3 /* YouTubeService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 77FA47CA28624D8B00E782D3 /* YouTubeService.swift */; };
+		77FA47CC28624D8B00E782D3 /* YouTubeService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 77FA47CA28624D8B00E782D3 /* YouTubeService.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -58,6 +60,7 @@
 		7706591E2861C074007248ED /* YouTubeViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = YouTubeViewModel.swift; sourceTree = "<group>"; };
 		770659222861D44C007248ED /* YouTubeResultParser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = YouTubeResultParser.swift; sourceTree = "<group>"; };
 		770659252861DEF6007248ED /* WebView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebView.swift; sourceTree = "<group>"; };
+		77FA47CA28624D8B00E782D3 /* YouTubeService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = YouTubeService.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -112,6 +115,7 @@
 				7706591E2861C074007248ED /* YouTubeViewModel.swift */,
 				770659222861D44C007248ED /* YouTubeResultParser.swift */,
 				770659252861DEF6007248ED /* WebView.swift */,
+				77FA47CA28624D8B00E782D3 /* YouTubeService.swift */,
 			);
 			path = Shared;
 			sourceTree = "<group>";
@@ -314,6 +318,7 @@
 				7706590C2861C05C007248ED /* ContentView.swift in Sources */,
 				770659262861DEF6007248ED /* WebView.swift in Sources */,
 				770659232861D44C007248ED /* YouTubeResultParser.swift in Sources */,
+				77FA47CB28624D8B00E782D3 /* YouTubeService.swift in Sources */,
 				7706590A2861C05C007248ED /* YouTubeTestApp.swift in Sources */,
 				7706591F2861C074007248ED /* YouTubeViewModel.swift in Sources */,
 			);
@@ -326,6 +331,7 @@
 				7706590D2861C05C007248ED /* ContentView.swift in Sources */,
 				770659272861DEF6007248ED /* WebView.swift in Sources */,
 				770659242861D44C007248ED /* YouTubeResultParser.swift in Sources */,
+				77FA47CC28624D8B00E782D3 /* YouTubeService.swift in Sources */,
 				7706590B2861C05C007248ED /* YouTubeTestApp.swift in Sources */,
 				770659202861C074007248ED /* YouTubeViewModel.swift in Sources */,
 			);


### PR DESCRIPTION
Stuff fixed post interview:
1. Encoding issue was caused by curl on Mac returning native YouTube, while iOS returns m.youtube - solved with request.setValue("Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:60.0) Gecko/20100101 Firefox/60.0", forHTTPHeaderField:"user-agent")
2. Fixed the code to match the design (extracted service logic)
3. Regex is still simplistic